### PR TITLE
Update README and configuration for Spec Driven Development Hackathon…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+layout: page
+title: Spec Driven Development Hackathon
+permalink: /github-copilot-advanced-hackathon
+---
 # Scenario : Spec Driven Development Programming Challenge
 
 Developers today agree that AI code assistant tools are useful for easy, repeatable tasks. JSON to Class, quick templated code, writing simple scripts. But most still think it's bad at more complex tasks. This exercise is here to show you that assumption is no longer as true as you might think! Spec-driven development takes your skills as a Software Engineer and augments your AI Coding Assistant to build software *your* way.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Spec Driven Development Hackathon
-permalink: /github-copilot-advanced-hackathon
+permalink: /
 ---
 # Scenario : Spec Driven Development Programming Challenge
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,16 +1,7 @@
 # Where things are
 source              : .
 destination         : ./_site
-collections_dir     : .
-plugins_dir         : _plugins # takes an array of strings and loads plugins in that order
-layouts_dir         : _layouts
-data_dir            : _data
-includes_dir        : _includes
-sass:
-  sass_dir: _sass
-collections:
-  posts:
-    output          : true
+baseurl: "/github-copilot-advanced-hackathon"
 
 # Handling Reading
 safe                : true
@@ -29,7 +20,7 @@ unpublished         : false
 
 # Plugins
 whitelist           : []
-plugins             : []
+plugins             : [jekyll-remote-theme, jemoji]
 
 # Conversion
 markdown            : kramdown
@@ -37,13 +28,6 @@ highlighter         : rouge
 lsi                 : false
 excerpt_separator   : "\n\n"
 incremental         : false
-
-# Serving
-detach              : false
-port                : 4000
-host                : 127.0.0.1
-baseurl             : "" # does not include hostname
-show_dir_listing    : false
 
 # Outputting
 permalink           : date
@@ -73,3 +57,4 @@ kramdown:
   syntax_highlighter: rouge
 
 theme: jekyll-theme-hacker
+remote_theme: pages-themes/hacker@v0.2.0


### PR DESCRIPTION
This pull request updates the project to support publishing a hackathon site using Jekyll and GitHub Pages. The main changes include adding front matter to the `README.md`, updating configuration for base URL and plugins, and switching to a remote theme.

Jekyll configuration updates:

* Set `baseurl` to `/github-copilot-advanced-hackathon` for correct site routing.
* Added `jekyll-remote-theme` and `jemoji` plugins to enable remote themes and emoji support.
* Removed unused configuration options related to collections, plugins, layouts, data, includes, sass, and serving to simplify the `_config.yml` file. [[1]](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L4-R4) [[2]](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L41-L47)

Theme and layout changes:

* Added `remote_theme: pages-themes/hacker@v0.2.0` and set `theme: jekyll-theme-hacker` for consistent styling using GitHub Pages themes.

Content updates:

* Added Jekyll front matter to `README.md` to enable it as the main page of the site with a custom title and permalink.… setup